### PR TITLE
Install Iso 8601 zones, replace duplicate data files with symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TZDB_DIR=$(CURDIR)/iana.org
 SRC_DIR=$(CURDIR)/src
 BUILD_DIR=$(CURDIR)/build
 INSTALL_DIR=/usr/share/tzdata-timed
+ZONE_INSTALL_DIR=/usr/share/zoneinfo
 INSTALL_ROOT?=""
 
 all: prepare-timed-data
@@ -74,6 +75,10 @@ install:
 	cp $(BUILD_DIR)/single.data $(INSTALL_ROOT)$(INSTALL_DIR)
 	cp $(BUILD_DIR)/zones-by-country.data $(INSTALL_ROOT)$(INSTALL_DIR)
 	cp $(BUILD_DIR)/zone.alias $(INSTALL_ROOT)$(INSTALL_DIR)
+	mkdir -p $(INSTALL_ROOT)$(ZONE_INSTALL_DIR) $(INSTALL_ROOT)$(ZONE_INSTALL_DIR)/right  $(INSTALL_ROOT)$(ZONE_INSTALL_DIR)/posix
+	cp -r $(BUILD_DIR)/zones/Iso8601 $(INSTALL_ROOT)$(ZONE_INSTALL_DIR)
+	cp -r $(BUILD_DIR)/zones/right/Iso8601 $(INSTALL_ROOT)$(ZONE_INSTALL_DIR)/right
+	cp -r $(BUILD_DIR)/zones/posix/Iso8601 $(INSTALL_ROOT)$(ZONE_INSTALL_DIR)/posix
 
 clean:
 	rm -rf $(SRC_DIR) $(BUILD_DIR)

--- a/rpm/tzdata-timed.spec
+++ b/rpm/tzdata-timed.spec
@@ -53,4 +53,5 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 # >> files
 %{_datadir}/tzdata-timed
+%{_datadir}/zoneinfo
 # << files

--- a/scripts/zone-generate.sh
+++ b/scripts/zone-generate.sh
@@ -108,6 +108,21 @@ zones=$(
   done
 )
 
+# Replace duplicates, hardlinks with symlinks. Adapted from Ubuntu tzdata
+# package version 2012e-0ubuntu0.12.04.1
+cd $output
+fdupes -1 -H -q -r . | while read line ; do
+    set -- ${line}
+    tgt="${1##./}"
+    shift
+    while [ "$#" != 0 ] ; do
+	link="${1##./}"
+	reltgt="$(echo $link | sed -e 's,[^/]\+$,,g' -e 's,[^/]\+,..,g')${tgt}"
+	ln -sf ${reltgt} ${link}
+	shift
+    done
+done
+
 ( cd $output && md5sum $zones ) > $md5sum
 $signature $output $zones > $signatures
 cat $input | pcregrep '^\s*Link\s+' > $links


### PR DESCRIPTION
Timed adds custom time zone information files to complement the set provided by package tzdata. These were left out of the tzdata-timed package, resulting in timed failing to set the time zone by UTC offset. This change set adds the extra time zone datafiles to the package and replaces any data file duplicates with soft links (like the tzdata package does.
